### PR TITLE
Dockerize matching service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 /*/.DS_Store
 /*/node_modules
 /*/.env
-*.env

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /*/.DS_Store
 /*/node_modules
 /*/.env
+*.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3.8"
+
+services:
+  mongodb:
+    image: mongo
+    restart: unless-stopped
+    env_file: ./.env
+    container_name: mongodb
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=$MONGODB_USER
+      - MONGO_INITDB_ROOT_PASSWORD=$MONGODB_PASSWORD
+    ports:
+      - $MONGODB_LOCAL_PORT:$MONGODB_DOCKER_PORT
+    volumes: # for data persistence
+      - mongodb_vol:/data/db
+      
+  matching-service:
+    container_name: matching-service
+    depends_on:
+      - mongodb
+    build: ./matching-service
+    restart: unless-stopped
+    env_file: ./.env
+    ports:
+      - $NODE_LOCAL_PORT:$NODE_DOCKER_PORT
+    # stdin_open: true
+    # tty: true
+
+volumes:
+  mongodb_vol:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,12 @@ services:
   mongodb:
     image: mongo
     restart: unless-stopped
-    env_file: ./.env
     container_name: mongodb
     environment:
-      - MONGO_INITDB_ROOT_USERNAME=$MONGODB_USER
-      - MONGO_INITDB_ROOT_PASSWORD=$MONGODB_PASSWORD
-    ports:
-      - $MONGODB_LOCAL_PORT:$MONGODB_DOCKER_PORT
+      - MONGO_INITDB_ROOT_USERNAME=mongo
+      - MONGO_INITDB_ROOT_PASSWORD=mongo123
+    ports: # 27018 in case there's another local mongo running, else 27017 is fine for LOCAL PORT as well
+      - 27018:27017
     volumes: # for data persistence
       - mongodb_vol:/data/db
       
@@ -20,9 +19,12 @@ services:
       - mongodb
     build: ./matching-service
     restart: unless-stopped
-    env_file: ./.env
-    ports:
-      - $NODE_LOCAL_PORT:$NODE_DOCKER_PORT
+    # note that the port specified in the conn string is the DOCKER PORT (27017), not LOCAL PORT (27018)
+    # authSource=admin is required as explained here: https://stackoverflow.com/questions/57434521/mongodb-could-not-find-user-userdatabase
+    environment: 
+      - DB_DOCKER_URI=mongodb://mongo:mongo123@mongodb:27017/matching-service?authSource=admin
+    ports: # 8002 in case there's local server running, else 8001 is fine for LOCAL PORT as well
+      - 8002:8001
     # stdin_open: true
     # tty: true
 

--- a/matching-service/.dockerignore
+++ b/matching-service/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/matching-service/dockerfile
+++ b/matching-service/dockerfile
@@ -1,0 +1,18 @@
+FROM node:16-alpine
+
+# Create app directory
+WORKDIR /usr/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY package*.json ./
+
+RUN npm install --quiet
+# If you are building your code for production
+# RUN npm ci --only=production
+
+# Bundle app source
+COPY . .
+
+CMD [ "node", "index.js" ]

--- a/matching-service/index.js
+++ b/matching-service/index.js
@@ -5,7 +5,16 @@ import matchRoutes from './routes/matchRoutes.js';
 import mongoose from 'mongoose';
 import 'dotenv/config'
 
-const uri = process.env.ENV == "PROD" ? process.env.DB_CLOUD_URI : process.env.DB_LOCAL_URI
+let uri;
+
+if (process.env.ENV == "PROD") {
+    uri = process.env.DB_CLOUD_URI
+} else if (process.env.DB_DOCKER_URI) {
+    uri = process.env.DB_DOCKER_URI
+} else {
+    uri = process.env.DB_LOCAL_URI
+}
+
 mongoose
     .connect(uri)
     .then((x) => console.log(`Connected to MongoDB! Database name: "${x.connections[0].name}"`))


### PR DESCRIPTION
* Add dockerfile
* Add docker-compose in root folder
* Tested with postman
* Please note the comments in `docker-compose.yaml`


In the future when dockerizing other microservices, can just add on to the docker-compose file and add your own dockerfile in the respective service. We may need to discuss port mapping as well for local ports of all the microservices to ensure no overlap.