### PR TITLE
Fix History-Service creating duplicate history for same interview

### DIFF
--- a/frontend/src/components/InterviewPage.js
+++ b/frontend/src/components/InterviewPage.js
@@ -35,7 +35,8 @@ const InterviewPage = () => {
                 username: username,
                 matchUsername: matchUsername,
                 difficulty: interviewDetails.data.difficulty,
-                question: interviewDetails.data.question
+                question: interviewDetails.data.question,
+                interviewId: interviewId
             }
             const res = await HistoryService.createHistory(history)
             if (res) console.log("history created")

--- a/history-service/controllers/historyController.js
+++ b/history-service/controllers/historyController.js
@@ -26,7 +26,7 @@ export const getHistory = async (req, res) => {
 
 export const deleteAllHistory = async (req, res) => {
     try {
-        const response = History.deleteMany({})
+        const response = await History.deleteMany({})
         return res.status(200).json(response)
     } catch (err) {
         res.status(500).json(err)

--- a/history-service/controllers/historyController.js
+++ b/history-service/controllers/historyController.js
@@ -23,3 +23,12 @@ export const getHistory = async (req, res) => {
         return res.status(500).json(err)
     }
 }
+
+export const deleteAllHistory = async (req, res) => {
+    try {
+        const response = History.deleteMany({})
+        return res.status(200).json(response)
+    } catch (err) {
+        res.status(500).json(err)
+    }
+}

--- a/history-service/controllers/historyController.js
+++ b/history-service/controllers/historyController.js
@@ -2,8 +2,13 @@ import History from "../models/history.js"
 
 export const createHistory = async (req, res) => {
     try {
-        const history = await History.create(req.body)
-        return res.status(200).json({ message: `interview history saved for ${history.username}` })
+        const history = await History.findOne(req.body)
+        if (history) {
+            return res.status(200).json({ message: `history already created previously for ${history.username}` })
+        } else {
+            history = await History.create(req.body)
+            return res.status(200).json({ message: `interview history saved for ${history.username}` })
+        }
     } catch (err) {
         return res.status(500).json(err)
     }

--- a/history-service/controllers/historyController.js
+++ b/history-service/controllers/historyController.js
@@ -2,11 +2,11 @@ import History from "../models/history.js"
 
 export const createHistory = async (req, res) => {
     try {
-        const history = await History.findOne(req.body)
-        if (history) {
+        const response = await History.findOne(req.body)
+        if (response) {
             return res.status(200).json({ message: `history already created previously for ${history.username}` })
         } else {
-            history = await History.create(req.body)
+            const history = await History.create(req.body)
             return res.status(200).json({ message: `interview history saved for ${history.username}` })
         }
     } catch (err) {

--- a/history-service/models/history.js
+++ b/history-service/models/history.js
@@ -16,6 +16,10 @@ const historySchema = new mongoose.Schema({
     question: {
         type: Object,
         required: true,
+    },
+    interviewId: {
+        type: Object,
+        required: true,
     }
 })
 

--- a/history-service/models/history.js
+++ b/history-service/models/history.js
@@ -18,7 +18,7 @@ const historySchema = new mongoose.Schema({
         required: true,
     },
     interviewId: {
-        type: Object,
+        type: String,
         required: true,
     }
 })

--- a/history-service/routes/historyRoutes.js
+++ b/history-service/routes/historyRoutes.js
@@ -4,5 +4,6 @@ import * as historyController from "../controllers/historyController.js"
 
 router.post("/create-history", historyController.createHistory)
 router.get("/get-history/:username", historyController.getHistory)
+router.delete("/delete-all-history", historyController.deleteAllHistory)
 
 export default router

--- a/history-service/test/test.js
+++ b/history-service/test/test.js
@@ -51,9 +51,6 @@ describe("history-service tests", () => {
                 done()
             })
         })
-        after(async () => {
-            await History.deleteOne({ _id: objectId })
-        })
     })
 
     describe("DELETE/delete-all-history/", () => {

--- a/history-service/test/test.js
+++ b/history-service/test/test.js
@@ -67,6 +67,7 @@ describe("history-service tests", () => {
                 assert.equal(res.body.acknowledged, true)
                 res.body.should.have.property("deletedCount")
                 assert.equal(res.body.deletedCount, 1)
+                done()
             })
         })
     })

--- a/history-service/test/test.js
+++ b/history-service/test/test.js
@@ -2,12 +2,9 @@ import chai, { assert } from "chai"
 import chaiHttp from "chai-http"
 import app from "../index.js"
 import { userHistory } from "./testData.js"
-import History from "../models/history.js"
 
 chai.use(chaiHttp)
 chai.should()
-
-let objectId;
 
 describe("history-service tests", () => {
     describe("POST/create-history", () => {
@@ -47,7 +44,8 @@ describe("history-service tests", () => {
                 assert.equal(res.body[0].question.description, "test")
                 res.body[0].should.have.nested.property("question.link")
                 assert.equal(res.body[0].question.link, "test")
-                objectId = res.body[0]._id
+                res.body[0].should.have.property("interviewId")
+                assert.equal(res.body[0].interviewId, "test")
                 done()
             })
         })

--- a/history-service/test/test.js
+++ b/history-service/test/test.js
@@ -13,6 +13,7 @@ describe("history-service tests", () => {
                 .post("/create-history")
                 .send(userHistory)
                 .end((err, res) => {
+                    console.log(res)
                     res.should.have.status(200)
                     res.body.should.be.a("object")
                     res.body.should.have.property("message")

--- a/history-service/test/test.js
+++ b/history-service/test/test.js
@@ -55,4 +55,19 @@ describe("history-service tests", () => {
             await History.deleteOne({ _id: objectId })
         })
     })
+
+    describe("DELETE/delete-all-history/", () => {
+        it("Delete all history successful", (done) => {
+            chai.request(app)
+            .delete(`/delete-all-history/`)
+            .end((err, res) => {
+                res.should.have.status(200)
+                res.body.should.be.a("object")
+                res.body.should.have.property("acknowledged")
+                assert.equal(res.body.acknowledged, true)
+                res.body.should.have.property("deletedCount")
+                assert.equal(res.body.deletedCount, 1)
+            })
+        })
+    })
 })

--- a/history-service/test/testData.js
+++ b/history-service/test/testData.js
@@ -7,5 +7,6 @@ export const userHistory = {
         title: "test",
         description: "test",
         link: "test"
-    }
+    },
+    interviewId: "test"
 }


### PR DESCRIPTION
- Created new deleteAllHistory API for history-service. Need to use this API using Postman to manually delete all the existing history initially. This is due to update of history schema to include interviewId for unique checks of history.
- createHistory API now checks for existing history before creating history due to inclusion of feature that allows users to return to existing interview that will cause duplicate history to be created without this check